### PR TITLE
Creados los modelos de Conversation y Message y el flujo para crear o…

### DIFF
--- a/back/src/main/java/com/proyectofinal/proyectofinal/model/Conversation.java
+++ b/back/src/main/java/com/proyectofinal/proyectofinal/model/Conversation.java
@@ -1,0 +1,37 @@
+package com.proyectofinal.proyectofinal.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class Conversation extends AbstractModel {
+    private static final Long TIMEOUT_MINUTES = 60L;
+
+    @ManyToOne
+    private ChatUser chatUser;
+    private LocalDateTime finalizedAt;
+
+    @OneToMany(mappedBy = "conversation", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @Builder.Default List<Message> messages = new ArrayList<>();
+
+    public LocalDateTime getLastMessageTime() {
+        if (messages.isEmpty()) {
+            return this.getCreatedAt();
+        }
+        return messages.getLast().getCreatedAt();
+    }
+
+    public boolean isRecentConversation() {
+        LocalDateTime lastMessageTime = getLastMessageTime();
+        return lastMessageTime.isAfter(LocalDateTime.now().minusMinutes(TIMEOUT_MINUTES));
+    }
+}

--- a/back/src/main/java/com/proyectofinal/proyectofinal/model/Message.java
+++ b/back/src/main/java/com/proyectofinal/proyectofinal/model/Message.java
@@ -1,0 +1,20 @@
+package com.proyectofinal.proyectofinal.model;
+
+import com.proyectofinal.proyectofinal.types.MessageOrigin;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class Message extends AbstractModel {
+    @ManyToOne(fetch = FetchType.LAZY)              // fetch preferible LAZY para evitar ciclos
+    @JoinColumn(name = "conversation_id")
+    private Conversation conversation;
+    private String content;
+
+    @Enumerated(EnumType.STRING) private MessageOrigin origin;
+}

--- a/back/src/main/java/com/proyectofinal/proyectofinal/repository/ConversationRepository.java
+++ b/back/src/main/java/com/proyectofinal/proyectofinal/repository/ConversationRepository.java
@@ -1,0 +1,11 @@
+package com.proyectofinal.proyectofinal.repository;
+
+import com.proyectofinal.proyectofinal.model.Conversation;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ConversationRepository extends AbstractRepository<Conversation>{
+    Optional<Conversation> findByChatUserIdAndFinalizedAtIsNull(Long userId);
+}

--- a/back/src/main/java/com/proyectofinal/proyectofinal/repository/MessageRepository.java
+++ b/back/src/main/java/com/proyectofinal/proyectofinal/repository/MessageRepository.java
@@ -1,0 +1,9 @@
+package com.proyectofinal.proyectofinal.repository;
+
+import com.proyectofinal.proyectofinal.model.Message;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MessageRepository extends AbstractRepository<Message>{
+
+}

--- a/back/src/main/java/com/proyectofinal/proyectofinal/service/ConversationFlowService.java
+++ b/back/src/main/java/com/proyectofinal/proyectofinal/service/ConversationFlowService.java
@@ -1,0 +1,34 @@
+package com.proyectofinal.proyectofinal.service;
+
+import com.proyectofinal.proyectofinal.model.ChatUser;
+import com.proyectofinal.proyectofinal.model.Conversation;
+import com.proyectofinal.proyectofinal.types.MessageOrigin;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ConversationFlowService {
+    public static final String NO_USER_RESPONSE = "Para comunicarte con el asistente virtual, por favor ingresá tu email empresarial";
+    public static final String BLOCKED_USER_RESPONSE = "No estás autorizado para comunicarte con el asistente virtual";
+
+    private final ChatUserService chatUserService;
+    private final ConversationService conversationService;
+    private final MessageService messageService;
+
+    public String getResponseForMessage(String messageContent, String phoneNumber) {
+        ChatUser chatUser = chatUserService.getOrCreateForPhone(messageContent, phoneNumber);
+        if (chatUser == null) {
+            return NO_USER_RESPONSE;
+        }
+
+        if (chatUser.isBlocked()) {
+            return BLOCKED_USER_RESPONSE;
+        }
+
+        Conversation conversation = conversationService.getOrCreateActiveConversationByUser(chatUser);
+        messageService.create(conversation, messageContent, MessageOrigin.USER);
+
+        return null; //TODO: get response from AI
+    }
+}

--- a/back/src/main/java/com/proyectofinal/proyectofinal/service/ConversationService.java
+++ b/back/src/main/java/com/proyectofinal/proyectofinal/service/ConversationService.java
@@ -1,0 +1,67 @@
+package com.proyectofinal.proyectofinal.service;
+
+import com.proyectofinal.proyectofinal.model.ChatUser;
+import com.proyectofinal.proyectofinal.model.Conversation;
+import com.proyectofinal.proyectofinal.repository.ConversationRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class ConversationService extends AbstractService<Conversation, ConversationRepository> {
+    public ConversationService(ConversationRepository repository) {
+        super(repository, Conversation.class);
+    }
+
+    public Conversation getOrCreateActiveConversationByUser(ChatUser chatUser) {
+        if (chatUser == null) {
+            throw new IllegalArgumentException("Error fetching active conversation: ChatUser is required");
+        }
+
+        Optional<Conversation> previousConversation = getActiveByUserId(chatUser.getId());
+        if (previousConversation.isPresent()) {
+            // Si encuentra una conversación válida la devuelve
+            previousConversation.get().getMessages().size(); // inicializa la colección
+            return previousConversation.get();
+        } else {
+            // Sino la crea
+            return create(chatUser);
+        }
+    }
+
+    private Optional<Conversation> getActiveByUserId(Long userId) {
+        // Buscamos una conversación anterior que no haya terminado
+        Optional<Conversation> previousConversation = repository.findByChatUserIdAndFinalizedAtIsNull(userId);
+
+        // Si la conversación existe y el último mensaje es reciente, la devolvemos
+        if (previousConversation.isPresent() && previousConversation.get().isRecentConversation()) {
+            return previousConversation;
+        } else if (previousConversation.isPresent()) {
+            // Si la conversación existe pero el último mensaje tiene más de una hora, la marcamos como finalizada
+            markAsFinished(previousConversation.get());
+        }
+
+        // Sea que la conversación era muy antigua o no encontró ninguna, devolvemos vacío
+        return Optional.empty();
+    }
+
+    public Conversation markAsFinished(Conversation conversation) {
+        if (conversation == null) {
+            throw new IllegalArgumentException("Error marking conversation as finished: Conversation is required");
+        }
+
+        conversation.setFinalizedAt(conversation.getLastMessageTime());
+        return repository.save(conversation);
+    }
+
+    public Conversation create(ChatUser chatUser) {
+        if (chatUser == null) {
+            throw new IllegalArgumentException("Error creating conversation: ChatUser is required");
+        }
+        Conversation conversation = Conversation.builder()
+                .chatUser(chatUser)
+                .build();
+
+        return repository.save(conversation);
+    }
+}

--- a/back/src/main/java/com/proyectofinal/proyectofinal/service/MessageService.java
+++ b/back/src/main/java/com/proyectofinal/proyectofinal/service/MessageService.java
@@ -1,27 +1,37 @@
 package com.proyectofinal.proyectofinal.service;
 
-import com.proyectofinal.proyectofinal.model.ChatUser;
-import lombok.RequiredArgsConstructor;
+import com.proyectofinal.proyectofinal.model.Conversation;
+import com.proyectofinal.proyectofinal.model.Message;
+import com.proyectofinal.proyectofinal.repository.MessageRepository;
+import com.proyectofinal.proyectofinal.types.MessageOrigin;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
-public class MessageService {
-    public static final String NO_USER_RESPONSE = "Para comunicarte con el asistente virtual, por favor ingresá tu email empresarial";
-    public static final String BLOCKED_USER_RESPONSE = "No estás autorizado para comunicarte con el asistente virtual";
+public class MessageService extends AbstractService<Message, MessageRepository>{
+    public MessageService(MessageRepository repository) {
+        super(repository, Message.class);
+    }
 
-    private final ChatUserService chatUserService;
+    public Message create(Conversation conversation, String content, MessageOrigin origin) {
+        checkElementsValidity(conversation, content, origin);
 
-    public String getResponseForMessage(String message, String phoneNumber) {
-        ChatUser chatUser = chatUserService.getOrCreateForPhone(message, phoneNumber);
-        if (chatUser == null) {
-            return NO_USER_RESPONSE;
+        Message message = Message.builder()
+                .conversation(conversation)
+                .content(content)
+                .origin(origin)
+                .build();
+
+        return repository.save(message);
+    }
+
+    private void checkElementsValidity(Conversation conversation, String content, MessageOrigin origin) {
+        if (conversation == null) {
+            throw new IllegalArgumentException("Error creating user: Conversation is required");
+        } else if (StringUtils.isEmpty(content)) {
+            throw new IllegalArgumentException("Error creating user: Message is empty");
+        } else if (origin == null) {
+            throw new IllegalArgumentException("Error creating user: Origin is required");
         }
-
-        if (chatUser.isBlocked()) {
-            return BLOCKED_USER_RESPONSE;
-        }
-
-        return null; //TODO: get response from AI
     }
 }

--- a/back/src/main/java/com/proyectofinal/proyectofinal/types/MessageOrigin.java
+++ b/back/src/main/java/com/proyectofinal/proyectofinal/types/MessageOrigin.java
@@ -1,0 +1,5 @@
+package com.proyectofinal.proyectofinal.types;
+
+public enum MessageOrigin {
+    USER, BOT
+}

--- a/back/src/test/java/com/proyectofinal/proyectofinal/AbstractTest.java
+++ b/back/src/test/java/com/proyectofinal/proyectofinal/AbstractTest.java
@@ -2,8 +2,10 @@ package com.proyectofinal.proyectofinal;
 
 import com.proyectofinal.proyectofinal.model.AppUser;
 import com.proyectofinal.proyectofinal.model.ChatUser;
+import com.proyectofinal.proyectofinal.model.Conversation;
 import com.proyectofinal.proyectofinal.service.AppUserService;
 import com.proyectofinal.proyectofinal.service.ChatUserService;
+import com.proyectofinal.proyectofinal.service.ConversationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -19,6 +21,9 @@ public abstract class AbstractTest {
     @Autowired
     private ChatUserService chatUserService;
 
+    @Autowired
+    private ConversationService conversationService;
+
     public AppUser getBaseUser() {
         return appUserService.getByEmail("admin@root.com");
     }
@@ -30,5 +35,9 @@ public abstract class AbstractTest {
                 .build();
 
         return chatUserService.save(existingChatUser);
+    }
+
+    protected Conversation createSampleConversation() {
+        return conversationService.create(createSampleChatUser());
     }
 }

--- a/back/src/test/java/com/proyectofinal/proyectofinal/model/ConversationTest.java
+++ b/back/src/test/java/com/proyectofinal/proyectofinal/model/ConversationTest.java
@@ -1,0 +1,43 @@
+package com.proyectofinal.proyectofinal.model;
+
+import com.proyectofinal.proyectofinal.AbstractTest;
+import com.proyectofinal.proyectofinal.types.MessageOrigin;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConversationTest extends AbstractTest {
+    @Test
+    void getLastMessageTime_noMessages_shouldReturnConversationCreatedAt() {
+        Conversation conversation = createSampleConversation();
+
+        assertTrue(conversation.getMessages().isEmpty());
+        assertEquals(conversation.getCreatedAt(), conversation.getLastMessageTime());
+    }
+
+    @Test
+    void getLastMessageTime_withMessages_shouldReturnLastMessageCreatedAt() {
+        Conversation conversation = createSampleConversation();
+
+        Message message1 = Message.builder()
+                .conversation(conversation)
+                .content("first message")
+                .origin(MessageOrigin.USER)
+                .build();
+        message1.setCreatedAt(LocalDateTime.now().plusMinutes(10L));
+
+        Message message2 = Message.builder()
+                .conversation(conversation)
+                .content("second message")
+                .origin(MessageOrigin.BOT)
+                .build();
+        message2.setCreatedAt(LocalDateTime.now().plusMinutes(20L));
+
+        conversation.getMessages().add(message1);
+        conversation.getMessages().add(message2);
+        assertFalse(conversation.getMessages().isEmpty());
+        assertEquals(message2.getCreatedAt(), conversation.getLastMessageTime());
+    }
+}

--- a/back/src/test/java/com/proyectofinal/proyectofinal/services/ConversationFlowTest.java
+++ b/back/src/test/java/com/proyectofinal/proyectofinal/services/ConversationFlowTest.java
@@ -1,0 +1,60 @@
+package com.proyectofinal.proyectofinal.services;
+
+import com.proyectofinal.proyectofinal.AbstractTest;
+import com.proyectofinal.proyectofinal.model.ChatUser;
+import com.proyectofinal.proyectofinal.model.Conversation;
+import com.proyectofinal.proyectofinal.service.ChatUserService;
+import com.proyectofinal.proyectofinal.service.ConversationFlowService;
+import com.proyectofinal.proyectofinal.service.ConversationService;
+import com.proyectofinal.proyectofinal.service.MessageService;
+import com.proyectofinal.proyectofinal.types.MessageOrigin;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+class ConversationFlowTest extends AbstractTest {
+    @Autowired
+    ChatUserService chatUserService;
+
+    @SpyBean
+    ConversationFlowService conversationFlowService;
+
+    @SpyBean
+    ConversationService conversationService;
+
+    @SpyBean
+    MessageService messageService;
+
+
+    @Test
+    void getResponseForMessage_userDoesNotExistAndCouldNotBeCreated() {
+        String response = conversationFlowService.getResponseForMessage("Hello there!", "11-1111-1111");
+
+        assertEquals(ConversationFlowService.NO_USER_RESPONSE, response);
+    }
+
+    @Test
+    void getResponseForMessage_userBlocked() {
+        ChatUser chatUser = createSampleChatUser();
+        chatUserService.markAsBlocked(chatUser.getExternalId());
+
+        String response = conversationFlowService.getResponseForMessage("Some message", chatUser.getPhoneNumber());
+
+        assertEquals(ConversationFlowService.BLOCKED_USER_RESPONSE, response);
+    }
+
+    @Test
+    void getResponseForMessage_validUser_createsMessageAndConversation() {
+        ChatUser chatUser = createSampleChatUser();
+        String messageContent = "Some message";
+        conversationFlowService.getResponseForMessage(messageContent, chatUser.getPhoneNumber());
+
+        verify(conversationService).getOrCreateActiveConversationByUser(chatUser);
+        verify(messageService).create(any(Conversation.class), eq(messageContent), eq(MessageOrigin.USER));
+    }
+}

--- a/back/src/test/java/com/proyectofinal/proyectofinal/services/ConversationServiceTest.java
+++ b/back/src/test/java/com/proyectofinal/proyectofinal/services/ConversationServiceTest.java
@@ -1,0 +1,111 @@
+package com.proyectofinal.proyectofinal.services;
+
+import com.proyectofinal.proyectofinal.AbstractTest;
+import com.proyectofinal.proyectofinal.model.ChatUser;
+import com.proyectofinal.proyectofinal.model.Conversation;
+import com.proyectofinal.proyectofinal.service.ConversationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ConversationServiceTest extends AbstractTest {
+    @SpyBean
+    ConversationService conversationService;
+
+    @Test
+    void create_chatUserIsNull() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> conversationService.create(null));
+        assertTrue(exception.getMessage().contains("ChatUser is required"));
+    }
+
+    @Test
+    void create_success() {
+        ChatUser chatUser = createSampleChatUser();
+
+        Conversation conversation = conversationService.create(chatUser);
+
+        assertNotNull(conversation.getId());
+        assertNotNull(conversation.getExternalId());
+        assertNotNull(conversation.getCreatedAt());
+        assertEquals(chatUser.getId(), conversation.getChatUser().getId());
+    }
+
+    @Test
+    void markAsFinished_conversationsNull() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> conversationService.markAsFinished(null));
+        assertTrue(exception.getMessage().contains("Conversation is required"));
+    }
+
+    @Test
+    void markAsFinished_success() {
+        Conversation originalConversation = createSampleConversation();
+
+        Conversation finishedConversation = conversationService.markAsFinished(originalConversation);
+        assertEquals(originalConversation.getId(), finishedConversation.getId());
+        assertEquals(originalConversation.getLastMessageTime(), finishedConversation.getFinalizedAt());
+    }
+
+    @Test
+    void getOrCreateActiveConversationByUserId_chatUserIsNull() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> conversationService.getOrCreateActiveConversationByUser(null));
+        assertTrue(exception.getMessage().contains("ChatUser is required"));
+
+        verify(conversationService, never()).create(any(ChatUser.class));
+    }
+
+    @Test
+    void getOrCreateActiveConversationByUserId_noPreviousConversation() {
+        ChatUser chatUser = createSampleChatUser();
+
+        conversationService.getOrCreateActiveConversationByUser(chatUser);
+        verify(conversationService).create(chatUser);
+    }
+
+    @Test
+    void getOrCreateActiveConversationByUserId_previousValidConversation() {
+        Conversation previousConversation = createSampleConversation();
+        ChatUser chatUser = previousConversation.getChatUser();
+        reset(conversationService);
+
+        Conversation conversation = conversationService.getOrCreateActiveConversationByUser(chatUser);
+        assertEquals(previousConversation.getId(), conversation.getId());
+        verify(conversationService, never()).create(chatUser);
+    }
+
+    @Test
+    void getOrCreateActiveConversationByUserId_previousFinalizedConversation() {
+        Conversation previousConversation = createSampleConversation();
+
+        conversationService.markAsFinished(previousConversation);
+
+        ChatUser chatUser = previousConversation.getChatUser();
+        reset(conversationService);
+
+        Conversation conversation = conversationService.getOrCreateActiveConversationByUser(chatUser);
+        assertNotEquals(previousConversation.getId(), conversation.getId());
+        verify(conversationService).create(chatUser);
+    }
+
+    @Test
+    void getOrCreateActiveConversationByUserId_previousInvalidConversation() {
+        Conversation previousConversation = createSampleConversation();
+
+        previousConversation.setCreatedAt(LocalDateTime.now().minusMinutes(120L));
+        conversationService.save(previousConversation);
+
+        ChatUser chatUser = previousConversation.getChatUser();
+        reset(conversationService);
+
+        Conversation conversation = conversationService.getOrCreateActiveConversationByUser(chatUser);
+        assertNotEquals(previousConversation.getId(), conversation.getId());
+        verify(conversationService).create(chatUser);
+        verify(conversationService).markAsFinished(previousConversation);
+    }
+}

--- a/back/src/test/java/com/proyectofinal/proyectofinal/services/MessageServiceTest.java
+++ b/back/src/test/java/com/proyectofinal/proyectofinal/services/MessageServiceTest.java
@@ -1,35 +1,54 @@
 package com.proyectofinal.proyectofinal.services;
 
 import com.proyectofinal.proyectofinal.AbstractTest;
-import com.proyectofinal.proyectofinal.model.ChatUser;
-import com.proyectofinal.proyectofinal.service.ChatUserService;
+import com.proyectofinal.proyectofinal.model.Conversation;
+import com.proyectofinal.proyectofinal.model.Message;
 import com.proyectofinal.proyectofinal.service.MessageService;
+import com.proyectofinal.proyectofinal.types.MessageOrigin;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class MessageServiceTest extends AbstractTest {
-    @Autowired
-    ChatUserService chatUserService;
-
+class MessageServiceTest extends AbstractTest {
     @Autowired
     MessageService messageService;
 
     @Test
-    void getResponseForMessage_userDoesNotExistAndCouldNotBeCreated() {
-        String response = messageService.getResponseForMessage("Hello there!", "11-1111-1111");
-
-        assertEquals(MessageService.NO_USER_RESPONSE, response);
+    void create_conversationIsNull() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> messageService.create(null, "test content", MessageOrigin.USER));
+        assertTrue(exception.getMessage().contains("Conversation is required"));
     }
 
     @Test
-    void getResponseForMessage_userBlocked() {
-        ChatUser chatUser = createSampleChatUser();
-        chatUserService.markAsBlocked(chatUser.getExternalId());
+    void create_contentIsNull() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> messageService.create(createSampleConversation(), null, MessageOrigin.USER));
+        assertTrue(exception.getMessage().contains("Message is empty"));
+    }
 
-        String response = messageService.getResponseForMessage("Some message", chatUser.getPhoneNumber());
+    @Test
+    void create_contentIsEmpty() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> messageService.create(createSampleConversation(), "", MessageOrigin.USER));
+        assertTrue(exception.getMessage().contains("Message is empty"));
+    }
 
-        assertEquals(MessageService.BLOCKED_USER_RESPONSE, response);
+    @Test
+    void create_originNull() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> messageService.create(createSampleConversation(), "test content", null));
+        assertTrue(exception.getMessage().contains("Origin is required"));
+    }
+
+    @Test
+    void create_success() {
+        Conversation conversation = createSampleConversation();
+        String content = "test content";
+        Message message = messageService.create(conversation, content, MessageOrigin.BOT);
+
+        assertNotNull(message.getId());
+        assertNotNull(message.getExternalId());
+        assertNotNull(message.getCreatedAt());
+        assertEquals(conversation.getId(), message.getConversation().getId());
+        assertEquals(content, message.getContent());
+        assertEquals(MessageOrigin.BOT, message.getOrigin());
     }
 }


### PR DESCRIPTION
Creados los modelos de Conversation y Message

Creado el flujo para crear (o fetchear conversación) y mensaje cuando llega un mensaje del usuario

Las conversaciones se dan por terminadas por dos causas:
1. se crea el reclamo y se manda el mail
2. pasó más de una hora desde el último mensaje

NOTA: es importante dividir los mensajes en conversaciones para proveer a la IA del contexto necesario (los mensajes de la conversación actual) a la hora de hacerle una pregunta y no mandar cosas de más porque eso podría llevar a que sobrepasemos el tamaño de la ventana de contexto y empiece a divagar